### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/SharkFinPro/VulkanRenderer/security/code-scanning/1](https://github.com/SharkFinPro/VulkanRenderer/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the `build` job in `.github/workflows/cmake-multi-platform.yml`. This block should grant only the minimum required permissions for the job to function. For a build job that checks out code, installs dependencies, builds, tests, and uploads artifacts, `contents: read` is sufficient. The `release` job already has its own `permissions` block, so no changes are needed there. The change should be made by inserting the following under the `build:` job definition, before `runs-on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
