### PR TITLE
Refactor RenderTarget API and consolidate image resource management

### DIFF
--- a/source/components/lighting/LightingManager.cpp
+++ b/source/components/lighting/LightingManager.cpp
@@ -9,7 +9,9 @@
 #include "../pipelines/descriptorSets/DescriptorSet.h"
 #include "../pipelines/pipelineManager/PipelineManager.h"
 #include "../pipelines/uniformBuffers/UniformBuffer.h"
+#include "../renderingManager/ImageResource.h"
 #include "../renderingManager/Renderer.h"
+#include "../renderingManager/RenderTarget.h"
 
 namespace {
 
@@ -307,7 +309,7 @@ namespace vke {
 
       imageInfos.push_back({
         m_shadowMapSampler,
-        light->getShadowMapView(),
+        light->getShadowMapRenderTarget()->getDepthImageResource(0).getImageView(),
         vk::ImageLayout::eDepthStencilReadOnlyOptimal
       });
 
@@ -397,7 +399,7 @@ namespace vke {
 
       imageInfos.push_back({
         m_shadowMapSampler,
-        light->getShadowMapView(),
+        light->getShadowMapRenderTarget()->getDepthImageResource(0).getImageView(),
         vk::ImageLayout::eDepthStencilReadOnlyOptimal
       });
 
@@ -464,7 +466,7 @@ namespace vke {
         .height = light->getShadowMapSize()
       };
 
-      m_renderer->beginShadowRendering(shadowExtent, commandBuffer, light);
+      m_renderer->beginShadowRendering(commandBuffer, light);
 
       vk::Viewport viewport {
         .x = 0.0f,
@@ -542,7 +544,7 @@ namespace vke {
         .height = light->getShadowMapSize()
       };
 
-      m_renderer->beginShadowRendering(shadowExtent, commandBuffer, light);
+      m_renderer->beginShadowRendering(commandBuffer, light);
 
       vk::Viewport viewport {
         .x = 0.0f,

--- a/source/components/lighting/lights/Light.cpp
+++ b/source/components/lighting/lights/Light.cpp
@@ -66,16 +66,6 @@ namespace vke {
     m_specular = specular;
   }
 
-  vk::Image Light::getShadowMap() const
-  {
-    return m_shadowMapRenderTarget->getDepthImageResource(0).getImage();
-  }
-
-  vk::ImageView Light::getShadowMapView() const
-  {
-    return m_shadowMapRenderTarget->getDepthImageResource(0).getImageView();
-  }
-
   uint32_t Light::getShadowMapSize() const
   {
     return m_shadowMapSize;

--- a/source/components/lighting/lights/Light.h
+++ b/source/components/lighting/lights/Light.h
@@ -71,10 +71,6 @@ namespace vke {
     void setDiffuse(float diffuse);
     void setSpecular(float specular);
 
-    [[nodiscard]] vk::Image getShadowMap() const;
-
-    [[nodiscard]] vk::ImageView getShadowMapView() const;
-
     [[nodiscard]] uint32_t getShadowMapSize() const;
 
     [[nodiscard]] bool castsShadows() const;

--- a/source/components/renderingManager/ImageResource.cpp
+++ b/source/components/renderingManager/ImageResource.cpp
@@ -203,7 +203,7 @@ namespace vke {
 
       if (config.imageResourceType == ImageResourceType::RayTracingOutput)
       {
-        return config.resolveFormat;
+        return config.rayTracingFormat;
       }
 
       return vk::Format::eUndefined;

--- a/source/components/renderingManager/ImageResource.h
+++ b/source/components/renderingManager/ImageResource.h
@@ -24,6 +24,7 @@ namespace vke {
     vk::Format colorFormat = vk::Format::eUndefined;
     vk::Format depthFormat = vk::Format::eUndefined;
     vk::Format resolveFormat = vk::Format::eUndefined;
+    vk::Format rayTracingFormat = vk::Format::eUndefined;
     vk::SampleCountFlagBits numSamples;
     vk::Sampler sampler = nullptr;
     bool isCubeMap = false;

--- a/source/components/renderingManager/RenderTarget.cpp
+++ b/source/components/renderingManager/RenderTarget.cpp
@@ -54,21 +54,6 @@ namespace vke {
     return m_resolveImageResources[imageIndex];
   }
 
-  uint32_t RenderTarget::hasColorImageResource() const
-  {
-    return m_colorImageResources.size();
-  }
-
-  uint32_t RenderTarget::hasDepthImageResource() const
-  {
-    return m_depthImageResources.size();
-  }
-
-  uint32_t RenderTarget::hasResolveImageResource() const
-  {
-    return m_resolveImageResources.size();
-  }
-
   vk::Extent2D RenderTarget::getExtent() const
   {
     return m_extent;

--- a/source/components/renderingManager/RenderTarget.cpp
+++ b/source/components/renderingManager/RenderTarget.cpp
@@ -3,10 +3,14 @@
 
 namespace vke {
   RenderTarget::RenderTarget(const ImageResourceConfig& imageResourceConfig,
-                             const uint32_t numImages)
+                             const uint32_t numImages,
+                             const bool createRayTracingResources)
     : m_extent(imageResourceConfig.extent)
   {
-    createRayTracingImageResources(imageResourceConfig, numImages);
+    if (createRayTracingResources)
+    {
+      createRayTracingImageResources(imageResourceConfig, numImages);
+    }
 
     createRasterizationImageResources(imageResourceConfig, numImages);
   }
@@ -36,13 +40,12 @@ namespace vke {
     return m_extent;
   }
 
-  void RenderTarget::createRayTracingImageResources(const ImageResourceConfig& imageResourceConfig,
+  void RenderTarget::createRayTracingImageResources(ImageResourceConfig imageResourceConfig,
                                                     const uint32_t numImages)
   {
-    if (imageResourceConfig.imageResourceType != ImageResourceType::RayTracingOutput)
-    {
-      return;
-    }
+    imageResourceConfig.imageResourceType = ImageResourceType::RayTracingOutput;
+    imageResourceConfig.colorFormat = vk::Format::eR8G8B8A8Uint;
+    imageResourceConfig.numSamples = vk::SampleCountFlagBits::e1;
 
     m_rayTracingImageResources.reserve(numImages);
 
@@ -55,11 +58,6 @@ namespace vke {
   void RenderTarget::createRasterizationImageResources(const ImageResourceConfig& imageResourceConfig,
                                                        const uint32_t numImages)
   {
-    if (imageResourceConfig.imageResourceType == ImageResourceType::RayTracingOutput)
-    {
-      return;
-    }
-
     m_colorImageResources.reserve(numImages);
     m_depthImageResources.reserve(numImages);
     m_resolveImageResources.reserve(numImages);

--- a/source/components/renderingManager/RenderTarget.cpp
+++ b/source/components/renderingManager/RenderTarget.cpp
@@ -6,6 +6,60 @@ namespace vke {
                              const uint32_t numImages)
     : m_extent(imageResourceConfig.extent)
   {
+    createRayTracingImageResources(imageResourceConfig, numImages);
+
+    createRasterizationImageResources(imageResourceConfig, numImages);
+  }
+
+  ImageResource& RenderTarget::getColorImageResource(const uint32_t imageIndex)
+  {
+    return m_colorImageResources.at(imageIndex);
+  }
+
+  ImageResource& RenderTarget::getDepthImageResource(const uint32_t imageIndex)
+  {
+    return m_depthImageResources.at(imageIndex);
+  }
+
+  ImageResource& RenderTarget::getResolveImageResource(const uint32_t imageIndex)
+  {
+    return m_resolveImageResources.at(imageIndex);
+  }
+
+  ImageResource& RenderTarget::getRayTracingImageResource(const uint32_t imageIndex)
+  {
+    return m_rayTracingImageResources.at(imageIndex);
+  }
+
+  vk::Extent2D RenderTarget::getExtent() const
+  {
+    return m_extent;
+  }
+
+  void RenderTarget::createRayTracingImageResources(const ImageResourceConfig& imageResourceConfig,
+                                                    const uint32_t numImages)
+  {
+    if (imageResourceConfig.imageResourceType != ImageResourceType::RayTracingOutput)
+    {
+      return;
+    }
+
+    m_rayTracingImageResources.reserve(numImages);
+
+    for (int i = 0; i < numImages; ++i)
+    {
+      m_rayTracingImageResources.emplace_back(imageResourceConfig);
+    }
+  }
+
+  void RenderTarget::createRasterizationImageResources(const ImageResourceConfig& imageResourceConfig,
+                                                       const uint32_t numImages)
+  {
+    if (imageResourceConfig.imageResourceType == ImageResourceType::RayTracingOutput)
+    {
+      return;
+    }
+
     m_colorImageResources.reserve(numImages);
     m_depthImageResources.reserve(numImages);
     m_resolveImageResources.reserve(numImages);
@@ -37,25 +91,5 @@ namespace vke {
         m_resolveImageResources.emplace_back(resolveImageResourceConfig);
       }
     }
-  }
-
-  ImageResource& RenderTarget::getColorImageResource(const uint32_t imageIndex)
-  {
-    return m_colorImageResources[imageIndex];
-  }
-
-  ImageResource& RenderTarget::getDepthImageResource(const uint32_t imageIndex)
-  {
-    return m_depthImageResources[imageIndex];
-  }
-
-  ImageResource& RenderTarget::getResolveImageResource(const uint32_t imageIndex)
-  {
-    return m_resolveImageResources[imageIndex];
-  }
-
-  vk::Extent2D RenderTarget::getExtent() const
-  {
-    return m_extent;
   }
 } // vke

--- a/source/components/renderingManager/RenderTarget.cpp
+++ b/source/components/renderingManager/RenderTarget.cpp
@@ -44,7 +44,7 @@ namespace vke {
                                                     const uint32_t numImages)
   {
     imageResourceConfig.imageResourceType = ImageResourceType::RayTracingOutput;
-    imageResourceConfig.colorFormat = vk::Format::eR8G8B8A8Uint;
+    imageResourceConfig.rayTracingFormat = vk::Format::eR8G8B8A8Unorm;
     imageResourceConfig.numSamples = vk::SampleCountFlagBits::e1;
 
     m_rayTracingImageResources.reserve(numImages);

--- a/source/components/renderingManager/RenderTarget.cpp
+++ b/source/components/renderingManager/RenderTarget.cpp
@@ -49,7 +49,7 @@ namespace vke {
 
     m_rayTracingImageResources.reserve(numImages);
 
-    for (int i = 0; i < numImages; ++i)
+    for (uint32_t i = 0; i < numImages; ++i)
     {
       m_rayTracingImageResources.emplace_back(imageResourceConfig);
     }
@@ -72,7 +72,7 @@ namespace vke {
     resolveImageResourceConfig.imageResourceType = ImageResourceType::Resolve;
     resolveImageResourceConfig.numSamples = vk::SampleCountFlagBits::e1;
 
-    for (int i = 0; i < numImages; ++i)
+    for (uint32_t i = 0; i < numImages; ++i)
     {
       if (imageResourceConfig.colorFormat != vk::Format::eUndefined)
       {

--- a/source/components/renderingManager/RenderTarget.h
+++ b/source/components/renderingManager/RenderTarget.h
@@ -20,6 +20,8 @@ namespace vke {
 
     [[nodiscard]] ImageResource& getResolveImageResource(uint32_t imageIndex);
 
+    [[nodiscard]] ImageResource& getRayTracingImageResource(uint32_t imageIndex);
+
     [[nodiscard]] vk::Extent2D getExtent() const;
 
   private:
@@ -27,7 +29,15 @@ namespace vke {
     std::vector<ImageResource> m_depthImageResources;
     std::vector<ImageResource> m_resolveImageResources;
 
+    std::vector<ImageResource> m_rayTracingImageResources;
+
     vk::Extent2D m_extent;
+
+    void createRayTracingImageResources(const ImageResourceConfig& imageResourceConfig,
+                                        uint32_t numImages);
+
+    void createRasterizationImageResources(const ImageResourceConfig& imageResourceConfig,
+                                          uint32_t numImages);
   };
 } // vke
 

--- a/source/components/renderingManager/RenderTarget.h
+++ b/source/components/renderingManager/RenderTarget.h
@@ -1,13 +1,11 @@
 #ifndef VULKANPROJECT_RENDERTARGET_H
 #define VULKANPROJECT_RENDERTARGET_H
 
+#include "ImageResource.h"
 #include <vulkan/vulkan_raii.hpp>
 #include <vector>
 
 namespace vke {
-
-  class ImageResource;
-  struct ImageResourceConfig;
 
   class RenderTarget {
   public:

--- a/source/components/renderingManager/RenderTarget.h
+++ b/source/components/renderingManager/RenderTarget.h
@@ -12,7 +12,8 @@ namespace vke {
   class RenderTarget {
   public:
     RenderTarget(const ImageResourceConfig& imageResourceConfig,
-                 uint32_t numImages);
+                 uint32_t numImages,
+                 bool createRayTracingResources = false);
 
     [[nodiscard]] ImageResource& getColorImageResource(uint32_t imageIndex);
 
@@ -33,7 +34,7 @@ namespace vke {
 
     vk::Extent2D m_extent;
 
-    void createRayTracingImageResources(const ImageResourceConfig& imageResourceConfig,
+    void createRayTracingImageResources(ImageResourceConfig imageResourceConfig,
                                         uint32_t numImages);
 
     void createRasterizationImageResources(const ImageResourceConfig& imageResourceConfig,

--- a/source/components/renderingManager/RenderTarget.h
+++ b/source/components/renderingManager/RenderTarget.h
@@ -20,12 +20,6 @@ namespace vke {
 
     [[nodiscard]] ImageResource& getResolveImageResource(uint32_t imageIndex);
 
-    [[nodiscard]] uint32_t hasColorImageResource() const;
-
-    [[nodiscard]] uint32_t hasDepthImageResource() const;
-
-    [[nodiscard]] uint32_t hasResolveImageResource() const;
-
     [[nodiscard]] vk::Extent2D getExtent() const;
 
   private:

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -292,7 +292,7 @@ namespace vke {
     m_offscreenRenderTarget = std::make_shared<RenderTarget>(
       imageResourceConfig,
       m_logicalDevice->getMaxFramesInFlight(),
-      true
+      m_logicalDevice->getPhysicalDevice()->supportsRayTracing()
     );
   }
 

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -31,11 +31,6 @@ namespace vke {
     return m_mousePickingRenderTarget;
   }
 
-  std::shared_ptr<RenderTarget> Renderer::getRayTracingRenderTarget() const
-  {
-    return m_rayTracingRenderTarget;
-  }
-
   void Renderer::resetSwapchainRenderTarget(const std::shared_ptr<SwapChain>& swapChain)
   {
     m_swapchainRenderTarget.reset();
@@ -48,8 +43,6 @@ namespace vke {
     m_offscreenRenderTarget.reset();
 
     createOffscreenRenderTarget(offscreenViewportExtent);
-
-    resetRayTracingRenderTarget(offscreenViewportExtent);
   }
 
   void Renderer::resetMousePickingRenderTarget(const vk::Extent2D mousePickingExtent)
@@ -216,7 +209,7 @@ namespace vke {
       .newLayout = vk::ImageLayout::eGeneral,
       .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
       .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
-      .image = m_rayTracingRenderTarget->getRayTracingImageResource(currentFrame).getImage(),
+      .image = m_offscreenRenderTarget->getRayTracingImageResource(currentFrame).getImage(),
       .subresourceRange = {
         .aspectMask = vk::ImageAspectFlagBits::eColor,
         .baseMipLevel = 0,
@@ -244,13 +237,6 @@ namespace vke {
     copyRayTracingImageToOffscreenImage(commandBuffer, currentFrame);
 
     transitionRayTracingImagePostCopy(commandBuffer, currentFrame);
-  }
-
-  void Renderer::resetRayTracingRenderTarget(const vk::Extent2D extent)
-  {
-    m_rayTracingRenderTarget.reset();
-
-    createRayTracingRenderTarget(extent);
   }
 
   void Renderer::createSampler()
@@ -303,7 +289,11 @@ namespace vke {
       .sampler = m_sampler
     };
 
-    m_offscreenRenderTarget = std::make_shared<RenderTarget>(imageResourceConfig, m_logicalDevice->getMaxFramesInFlight());
+    m_offscreenRenderTarget = std::make_shared<RenderTarget>(
+      imageResourceConfig,
+      m_logicalDevice->getMaxFramesInFlight(),
+      true
+    );
   }
 
   void Renderer::createMousePickingRenderTarget(const vk::Extent2D extent)
@@ -318,25 +308,6 @@ namespace vke {
     };
 
     m_mousePickingRenderTarget = std::make_shared<RenderTarget>(imageResourceConfig, m_logicalDevice->getMaxFramesInFlight());
-  }
-
-  void Renderer::createRayTracingRenderTarget(const vk::Extent2D extent)
-  {
-    if (!m_logicalDevice->getPhysicalDevice()->supportsRayTracing())
-    {
-      return;
-    }
-    
-    ImageResourceConfig imageResourceConfig {
-      .imageResourceType = ImageResourceType::RayTracingOutput,
-      .logicalDevice = m_logicalDevice,
-      .extent = extent,
-      .commandPool = m_commandPool,
-      .resolveFormat = vk::Format::eR8G8B8A8Unorm,
-      .numSamples = vk::SampleCountFlagBits::e1
-    };
-
-    m_rayTracingRenderTarget = std::make_shared<RenderTarget>(imageResourceConfig, m_logicalDevice->getMaxFramesInFlight());
   }
 
   void Renderer::transitionSwapchainImagePreRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
@@ -402,7 +373,7 @@ namespace vke {
   void Renderer::transitionRayTracingImagePreCopy(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                                   const uint32_t currentFrame) const
   {
-    const auto rtImage = m_rayTracingRenderTarget->getRayTracingImageResource(currentFrame).getImage();
+    const auto rtImage = m_offscreenRenderTarget->getRayTracingImageResource(currentFrame).getImage();
     const auto offscreenImage = m_offscreenRenderTarget->getResolveImageResource(currentFrame).getImage();
 
     // Transition RT image: GENERAL -> TRANSFER_SRC_OPTIMAL
@@ -455,7 +426,7 @@ namespace vke {
   void Renderer::transitionRayTracingImagePostCopy(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                                    const uint32_t currentFrame) const
   {
-    const auto rtImage = m_rayTracingRenderTarget->getRayTracingImageResource(currentFrame).getImage();
+    const auto rtImage = m_offscreenRenderTarget->getRayTracingImageResource(currentFrame).getImage();
     const auto offscreenImage = m_offscreenRenderTarget->getResolveImageResource(currentFrame).getImage();
 
     // Transition offscreen resolve: TRANSFER_DST_OPTIMAL -> SHADER_READ_ONLY_OPTIMAL
@@ -508,7 +479,7 @@ namespace vke {
   void Renderer::copyRayTracingImageToOffscreenImage(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                                      const uint32_t currentFrame) const
   {
-    const auto rtImage = m_rayTracingRenderTarget->getRayTracingImageResource(currentFrame).getImage();
+    const auto rtImage = m_offscreenRenderTarget->getRayTracingImageResource(currentFrame).getImage();
     const auto offscreenImage = m_offscreenRenderTarget->getResolveImageResource(currentFrame).getImage();
 
     const auto extent = m_offscreenRenderTarget->getExtent();

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -134,12 +134,13 @@ namespace vke {
     commandBuffer->beginRendering(renderingInfo);
   }
 
-  void Renderer::beginShadowRendering(const vk::Extent2D extent,
-                                      const std::shared_ptr<CommandBuffer>& commandBuffer,
+  void Renderer::beginShadowRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                       const std::shared_ptr<Light>& light)
   {
+    const auto shadowMapRenderTarget = light->getShadowMapRenderTarget();
+
     vk::RenderingAttachmentInfo depthRenderingAttachmentInfo {
-      .imageView = light->getShadowMapView(),
+      .imageView = shadowMapRenderTarget->getDepthImageResource(0).getImageView(),
       .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
       .loadOp = vk::AttachmentLoadOp::eClear,
       .storeOp = vk::AttachmentStoreOp::eStore,
@@ -150,7 +151,7 @@ namespace vke {
     const vk::RenderingInfo renderingInfo {
       .renderArea = {
         .offset = {0, 0},
-        .extent = extent,
+        .extent = shadowMapRenderTarget->getExtent(),
       },
       .layerCount = 1,
       .viewMask = light->getLightType() == LightType::pointLight ? kCubemapFacesMask : 0,

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -60,7 +60,6 @@ namespace vke {
   }
 
   void Renderer::beginSwapchainRendering(const uint32_t imageIndex,
-                                         const vk::Extent2D extent,
                                          const std::shared_ptr<CommandBuffer>& commandBuffer,
                                          const std::shared_ptr<SwapChain>& swapChain) const
   {
@@ -88,7 +87,7 @@ namespace vke {
     const vk::RenderingInfo renderingInfo {
       .renderArea = {
         .offset = {0, 0},
-        .extent = extent,
+        .extent = m_swapchainRenderTarget->getExtent(),
       },
       .layerCount = 1,
       .colorAttachmentCount = 1,
@@ -100,7 +99,6 @@ namespace vke {
   }
 
   void Renderer::beginOffscreenRendering(const uint32_t currentFrame,
-                                         const vk::Extent2D extent,
                                          const std::shared_ptr<CommandBuffer>& commandBuffer) const
   {
     vk::RenderingAttachmentInfo colorRenderingAttachmentInfo {
@@ -125,7 +123,7 @@ namespace vke {
     const vk::RenderingInfo renderingInfo {
       .renderArea = {
         .offset = {0, 0},
-        .extent = extent,
+        .extent = m_offscreenRenderTarget->getExtent(),
       },
       .layerCount = 1,
       .colorAttachmentCount = 1,
@@ -165,7 +163,6 @@ namespace vke {
   }
 
   void Renderer::beginMousePickingRendering(const uint32_t currentFrame,
-                                            const vk::Extent2D extent,
                                             const std::shared_ptr<CommandBuffer>& commandBuffer) const
   {
     vk::RenderingAttachmentInfo colorRenderingAttachmentInfo {
@@ -188,7 +185,7 @@ namespace vke {
     const vk::RenderingInfo renderingInfo {
       .renderArea = {
         .offset = {0, 0},
-        .extent = extent,
+        .extent = m_mousePickingRenderTarget->getExtent(),
       },
       .layerCount = 1,
       .colorAttachmentCount = 1,

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -21,14 +21,9 @@ namespace vke {
     createMousePickingRenderTarget(swapChain->getExtent());
   }
 
-  vk::DescriptorSet Renderer::getOffscreenImageDescriptorSet(const uint32_t imageIndex) const
+  std::shared_ptr<RenderTarget> Renderer::getOffscreenRenderTarget() const
   {
-    if (!m_offscreenRenderTarget)
-    {
-      return nullptr;
-    }
-
-    return m_offscreenRenderTarget->getResolveImageResource(imageIndex).getDescriptorSet();
+    return m_offscreenRenderTarget;
   }
 
   std::shared_ptr<RenderTarget> Renderer::getMousePickingRenderTarget() const

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -36,6 +36,11 @@ namespace vke {
     return m_mousePickingRenderTarget;
   }
 
+  std::shared_ptr<RenderTarget> Renderer::getRayTracingRenderTarget() const
+  {
+    return m_rayTracingRenderTarget;
+  }
+
   void Renderer::resetSwapchainImageResources(const std::shared_ptr<SwapChain>& swapChain)
   {
     m_swapchainRenderTarget.reset();
@@ -215,7 +220,7 @@ namespace vke {
       .newLayout = vk::ImageLayout::eGeneral,
       .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
       .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
-      .image = getRayTracingImageResource(currentFrame)->getImage(),
+      .image = m_rayTracingRenderTarget->getRayTracingImageResource(currentFrame).getImage(),
       .subresourceRange = {
         .aspectMask = vk::ImageAspectFlagBits::eColor,
         .baseMipLevel = 0,
@@ -247,14 +252,9 @@ namespace vke {
 
   void Renderer::resetRayTracingImageResources(const vk::Extent2D extent)
   {
-    m_rayTracingImageResources.clear();
+    m_rayTracingRenderTarget.reset();
 
     createRayTracingImageResource(extent);
-  }
-
-  std::shared_ptr<ImageResource> Renderer::getRayTracingImageResource(const uint32_t currentFrame) const
-  {
-    return m_rayTracingImageResources.at(currentFrame);
   }
 
   void Renderer::createSampler()
@@ -340,10 +340,7 @@ namespace vke {
       .numSamples = vk::SampleCountFlagBits::e1
     };
 
-    for (size_t i = 0; i < m_logicalDevice->getMaxFramesInFlight(); ++i)
-    {
-      m_rayTracingImageResources.emplace_back(std::make_shared<ImageResource>(imageResourceConfig));
-    }
+    m_rayTracingRenderTarget = std::make_shared<RenderTarget>(imageResourceConfig, m_logicalDevice->getMaxFramesInFlight());
   }
 
   void Renderer::transitionSwapchainImagePreRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
@@ -409,7 +406,7 @@ namespace vke {
   void Renderer::transitionRayTracingImagePreCopy(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                                   const uint32_t currentFrame) const
   {
-    const auto rtImage = getRayTracingImageResource(currentFrame)->getImage();
+    const auto rtImage = m_rayTracingRenderTarget->getRayTracingImageResource(currentFrame).getImage();
     const auto offscreenImage = m_offscreenRenderTarget->getResolveImageResource(currentFrame).getImage();
 
     // Transition RT image: GENERAL -> TRANSFER_SRC_OPTIMAL
@@ -462,7 +459,7 @@ namespace vke {
   void Renderer::transitionRayTracingImagePostCopy(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                                    const uint32_t currentFrame) const
   {
-    const auto rtImage = getRayTracingImageResource(currentFrame)->getImage();
+    const auto rtImage = m_rayTracingRenderTarget->getRayTracingImageResource(currentFrame).getImage();
     const auto offscreenImage = m_offscreenRenderTarget->getResolveImageResource(currentFrame).getImage();
 
     // Transition offscreen resolve: TRANSFER_DST_OPTIMAL -> SHADER_READ_ONLY_OPTIMAL
@@ -515,7 +512,7 @@ namespace vke {
   void Renderer::copyRayTracingImageToOffscreenImage(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                                      const uint32_t currentFrame) const
   {
-    const auto rtImage = getRayTracingImageResource(currentFrame)->getImage();
+    const auto rtImage = m_rayTracingRenderTarget->getRayTracingImageResource(currentFrame).getImage();
     const auto offscreenImage = m_offscreenRenderTarget->getResolveImageResource(currentFrame).getImage();
 
     const auto extent = m_offscreenRenderTarget->getExtent();

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -41,23 +41,23 @@ namespace vke {
     return m_rayTracingRenderTarget;
   }
 
-  void Renderer::resetSwapchainImageResources(const std::shared_ptr<SwapChain>& swapChain)
+  void Renderer::resetSwapchainRenderTarget(const std::shared_ptr<SwapChain>& swapChain)
   {
     m_swapchainRenderTarget.reset();
 
     createSwapchainRenderTarget(swapChain);
   }
 
-  void Renderer::resetOffscreenImageResources(const vk::Extent2D offscreenViewportExtent)
+  void Renderer::resetOffscreenRenderTarget(const vk::Extent2D offscreenViewportExtent)
   {
     m_offscreenRenderTarget.reset();
 
     createOffscreenRenderTarget(offscreenViewportExtent);
 
-    resetRayTracingImageResources(offscreenViewportExtent);
+    resetRayTracingRenderTarget(offscreenViewportExtent);
   }
 
-  void Renderer::resetMousePickingImageResources(const vk::Extent2D mousePickingExtent)
+  void Renderer::resetMousePickingRenderTarget(const vk::Extent2D mousePickingExtent)
   {
     m_mousePickingRenderTarget.reset();
 
@@ -250,11 +250,11 @@ namespace vke {
     transitionRayTracingImagePostCopy(commandBuffer, currentFrame);
   }
 
-  void Renderer::resetRayTracingImageResources(const vk::Extent2D extent)
+  void Renderer::resetRayTracingRenderTarget(const vk::Extent2D extent)
   {
     m_rayTracingRenderTarget.reset();
 
-    createRayTracingImageResource(extent);
+    createRayTracingRenderTarget(extent);
   }
 
   void Renderer::createSampler()
@@ -324,7 +324,7 @@ namespace vke {
     m_mousePickingRenderTarget = std::make_shared<RenderTarget>(imageResourceConfig, m_logicalDevice->getMaxFramesInFlight());
   }
 
-  void Renderer::createRayTracingImageResource(const vk::Extent2D extent)
+  void Renderer::createRayTracingRenderTarget(const vk::Extent2D extent)
   {
     if (!m_logicalDevice->getPhysicalDevice()->supportsRayTracing())
     {

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -40,8 +40,7 @@ namespace vke {
     void beginOffscreenRendering(uint32_t currentFrame,
                                  const std::shared_ptr<CommandBuffer>& commandBuffer) const;
 
-    static void beginShadowRendering(vk::Extent2D extent,
-                                     const std::shared_ptr<CommandBuffer>& commandBuffer,
+    static void beginShadowRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                      const std::shared_ptr<Light>& light);
 
     void beginMousePickingRendering(uint32_t currentFrame,

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -33,12 +33,10 @@ namespace vke {
     void resetRayTracingImageResources(vk::Extent2D extent);
 
     void beginSwapchainRendering(uint32_t imageIndex,
-                                 vk::Extent2D extent,
                                  const std::shared_ptr<CommandBuffer>& commandBuffer,
                                  const std::shared_ptr<SwapChain>& swapChain) const;
 
     void beginOffscreenRendering(uint32_t currentFrame,
-                                 vk::Extent2D extent,
                                  const std::shared_ptr<CommandBuffer>& commandBuffer) const;
 
     static void beginShadowRendering(vk::Extent2D extent,
@@ -46,7 +44,6 @@ namespace vke {
                                      const std::shared_ptr<Light>& light);
 
     void beginMousePickingRendering(uint32_t currentFrame,
-                                    vk::Extent2D extent,
                                     const std::shared_ptr<CommandBuffer>& commandBuffer) const;
 
     static void endSwapchainRendering(uint32_t imageIndex,

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -23,15 +23,11 @@ namespace vke {
 
     [[nodiscard]] std::shared_ptr<RenderTarget> getMousePickingRenderTarget() const;
 
-    [[nodiscard]] std::shared_ptr<RenderTarget> getRayTracingRenderTarget() const;
-
     void resetSwapchainRenderTarget(const std::shared_ptr<SwapChain>& swapChain);
 
     void resetOffscreenRenderTarget(vk::Extent2D offscreenViewportExtent);
 
     void resetMousePickingRenderTarget(vk::Extent2D mousePickingExtent);
-
-    void resetRayTracingRenderTarget(vk::Extent2D extent);
 
     void beginSwapchainRendering(uint32_t imageIndex,
                                  const std::shared_ptr<CommandBuffer>& commandBuffer,
@@ -73,8 +69,6 @@ namespace vke {
 
     std::shared_ptr<RenderTarget> m_mousePickingRenderTarget;
 
-    std::shared_ptr<RenderTarget> m_rayTracingRenderTarget;
-
     vk::raii::Sampler m_sampler = nullptr;
 
     void createSampler();
@@ -84,8 +78,6 @@ namespace vke {
     void createOffscreenRenderTarget(vk::Extent2D extent);
 
     void createMousePickingRenderTarget(vk::Extent2D extent);
-
-    void createRayTracingRenderTarget(vk::Extent2D extent);
     
     static void transitionSwapchainImagePreRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                                   vk::Image image);

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -19,7 +19,7 @@ namespace vke {
                       const std::shared_ptr<SwapChain>& swapChain,
                       vk::CommandPool commandPool);
 
-    [[nodiscard]] vk::DescriptorSet getOffscreenImageDescriptorSet(uint32_t imageIndex) const;
+    [[nodiscard]] std::shared_ptr<RenderTarget> getOffscreenRenderTarget() const;
 
     [[nodiscard]] std::shared_ptr<RenderTarget> getMousePickingRenderTarget() const;
 

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -24,6 +24,8 @@ namespace vke {
 
     [[nodiscard]] std::shared_ptr<RenderTarget> getMousePickingRenderTarget() const;
 
+    [[nodiscard]] std::shared_ptr<RenderTarget> getRayTracingRenderTarget() const;
+
     void resetSwapchainImageResources(const std::shared_ptr<SwapChain>& swapChain);
 
     void resetOffscreenImageResources(vk::Extent2D offscreenViewportExtent);
@@ -56,8 +58,6 @@ namespace vke {
     void endRayTracingRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                 uint32_t currentFrame) const;
 
-    [[nodiscard]] std::shared_ptr<ImageResource> getRayTracingImageResource(uint32_t currentFrame) const;
-
   protected:
     static constexpr vk::ClearValue s_clearColor = vk::ClearColorValue(0.0f, 0.0f, 0.0f, 1.0f);
     static constexpr vk::ClearValue s_clearDepth = vk::ClearDepthStencilValue{
@@ -75,7 +75,7 @@ namespace vke {
 
     std::shared_ptr<RenderTarget> m_mousePickingRenderTarget;
 
-    std::vector<std::shared_ptr<ImageResource>> m_rayTracingImageResources;
+    std::shared_ptr<RenderTarget> m_rayTracingRenderTarget;
 
     vk::raii::Sampler m_sampler = nullptr;
 

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -8,7 +8,6 @@
 namespace vke {
 
   class CommandBuffer;
-  class ImageResource;
   class Light;
   class LogicalDevice;
   class RenderTarget;
@@ -26,13 +25,13 @@ namespace vke {
 
     [[nodiscard]] std::shared_ptr<RenderTarget> getRayTracingRenderTarget() const;
 
-    void resetSwapchainImageResources(const std::shared_ptr<SwapChain>& swapChain);
+    void resetSwapchainRenderTarget(const std::shared_ptr<SwapChain>& swapChain);
 
-    void resetOffscreenImageResources(vk::Extent2D offscreenViewportExtent);
+    void resetOffscreenRenderTarget(vk::Extent2D offscreenViewportExtent);
 
-    void resetMousePickingImageResources(vk::Extent2D mousePickingExtent);
+    void resetMousePickingRenderTarget(vk::Extent2D mousePickingExtent);
 
-    void resetRayTracingImageResources(vk::Extent2D extent);
+    void resetRayTracingRenderTarget(vk::Extent2D extent);
 
     void beginSwapchainRendering(uint32_t imageIndex,
                                  const std::shared_ptr<CommandBuffer>& commandBuffer,
@@ -87,7 +86,7 @@ namespace vke {
 
     void createMousePickingRenderTarget(vk::Extent2D extent);
 
-    void createRayTracingImageResource(vk::Extent2D extent);
+    void createRayTracingRenderTarget(vk::Extent2D extent);
     
     static void transitionSwapchainImagePreRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                                   vk::Image image);

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -262,7 +262,7 @@ namespace vke {
       if (m_rayTracingEnabled)
       {
         m_renderer->beginRayTracingRendering(m_offscreenCommandBuffer, currentFrame);
-        m_renderer3D->doRayTracing(&renderInfo, pipelineManager, lightingManager, m_renderer->getRayTracingRenderTarget()->getRayTracingImageResource(currentFrame));
+        m_renderer3D->doRayTracing(&renderInfo, pipelineManager, lightingManager, m_renderer->getOffscreenRenderTarget()->getRayTracingImageResource(currentFrame));
         m_renderer->endRayTracingRendering(m_offscreenCommandBuffer, currentFrame);
 
         return;

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -260,7 +260,7 @@ namespace vke {
       if (m_rayTracingEnabled)
       {
         m_renderer->beginRayTracingRendering(m_offscreenCommandBuffer, currentFrame);
-        m_renderer3D->doRayTracing(&renderInfo, pipelineManager, lightingManager, m_renderer->getRayTracingImageResource(currentFrame));
+        m_renderer3D->doRayTracing(&renderInfo, pipelineManager, lightingManager, m_renderer->getRayTracingRenderTarget()->getRayTracingImageResource(currentFrame));
         m_renderer->endRayTracingRendering(m_offscreenCommandBuffer, currentFrame);
 
         return;

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -230,7 +230,9 @@ namespace vke {
     m_offscreenViewportPos = ImGui::GetCursorScreenPos();
     m_renderer3D->getMousePicker()->setViewportPos(m_offscreenViewportPos);
 
-    ImGui::Image(static_cast<ImTextureRef>(m_renderer->getOffscreenImageDescriptorSet(currentFrame)), contentRegionAvailable);
+    const auto offscreenImageDescriptorSet = m_renderer->getOffscreenRenderTarget()->getResolveImageResource(currentFrame).getDescriptorSet();
+
+    ImGui::Image(static_cast<ImTextureRef>(offscreenImageDescriptorSet), contentRegionAvailable);
 
     ImGui::End();
   }

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -249,7 +249,7 @@ namespace vke {
     };
 
     auto recordMousePicking = [&](const RenderInfo& renderInfo) {
-      m_renderer->beginMousePickingRendering(currentFrame, renderInfo.extent, renderInfo.commandBuffer);
+      m_renderer->beginMousePickingRendering(currentFrame, renderInfo.commandBuffer);
 
       m_renderer3D->renderMousePicking(&renderInfo, pipelineManager);
 
@@ -266,7 +266,7 @@ namespace vke {
         return;
       }
 
-      m_renderer->beginOffscreenRendering(currentFrame, m_offscreenViewportExtent, m_offscreenCommandBuffer);
+      m_renderer->beginOffscreenRendering(currentFrame, m_offscreenCommandBuffer);
 
       m_renderer3D->render(&renderInfo, pipelineManager, lightingManager);
 
@@ -371,7 +371,7 @@ namespace vke {
       };
       renderInfo.commandBuffer->setScissor(scissor);
 
-      m_renderer->beginSwapchainRendering(imageIndex, m_swapChain->getExtent(), renderInfo.commandBuffer, m_swapChain);
+      m_renderer->beginSwapchainRendering(imageIndex, renderInfo.commandBuffer, m_swapChain);
 
       if (!m_shouldRenderOffscreen)
       {

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -126,7 +126,7 @@ namespace vke {
 
     m_swapChain = std::make_shared<SwapChain>(m_logicalDevice, m_window, m_surface);
 
-    m_renderer->resetSwapchainImageResources(m_swapChain);
+    m_renderer->resetSwapchainRenderTarget(m_swapChain);
 
     if (m_shouldRenderOffscreen)
     {
@@ -135,14 +135,14 @@ namespace vke {
         return;
       }
 
-      m_renderer->resetOffscreenImageResources(m_offscreenViewportExtent);
+      m_renderer->resetOffscreenRenderTarget(m_offscreenViewportExtent);
 
-      m_renderer->resetMousePickingImageResources(m_offscreenViewportExtent);
+      m_renderer->resetMousePickingRenderTarget(m_offscreenViewportExtent);
       m_renderer3D->getMousePicker()->setViewportExtent(m_offscreenViewportExtent);
     }
     else
     {
-      m_renderer->resetMousePickingImageResources(m_swapChain->getExtent());
+      m_renderer->resetMousePickingRenderTarget(m_swapChain->getExtent());
       m_renderer3D->getMousePicker()->setViewportExtent(m_swapChain->getExtent());
     }
   }
@@ -221,9 +221,9 @@ namespace vke {
 
       m_logicalDevice->waitIdle();
 
-      m_renderer->resetOffscreenImageResources(m_offscreenViewportExtent);
+      m_renderer->resetOffscreenRenderTarget(m_offscreenViewportExtent);
 
-      m_renderer->resetMousePickingImageResources(m_offscreenViewportExtent);
+      m_renderer->resetMousePickingRenderTarget(m_offscreenViewportExtent);
       m_renderer3D->getMousePicker()->setViewportExtent(m_offscreenViewportExtent);
     }
 

--- a/source/components/renderingManager/renderer3D/RayTracer.cpp
+++ b/source/components/renderingManager/renderer3D/RayTracer.cpp
@@ -54,7 +54,7 @@ namespace vke {
   void RayTracer::doRayTracing(const RenderInfo* renderInfo,
                                const std::shared_ptr<PipelineManager>& pipelineManager,
                                const std::shared_ptr<LightingManager>& lightingManager,
-                               const std::shared_ptr<ImageResource>& imageResource,
+                               const ImageResource& imageResource,
                                const std::vector<std::shared_ptr<RenderObject>>& renderObjects,
                                const std::shared_ptr<Cloud>& cloud,
                                const glm::vec3& viewPosition,
@@ -422,10 +422,10 @@ namespace vke {
     uploadBuffer(meshInfos, m_meshInfoBuffer, m_meshInfoBufferMemory);
   }
 
-  void RayTracer::updateRTDescriptorSets(const std::shared_ptr<ImageResource>& imageResource,
+  void RayTracer::updateRTDescriptorSets(const ImageResource& imageResource,
                                          const uint32_t currentFrame)
   {
-    m_rayTracingDescriptorSet->updateDescriptorSets([this, imageResource, currentFrame](const vk::DescriptorSet descriptorSet, [[maybe_unused]] const size_t frame)
+    m_rayTracingDescriptorSet->updateDescriptorSets([this, &imageResource, currentFrame](const vk::DescriptorSet descriptorSet, [[maybe_unused]] const size_t frame)
     {
       auto storageBuffer = [&](const uint32_t binding, const vk::DescriptorBufferInfo* info) {
         return vk::WriteDescriptorSet {
@@ -450,7 +450,7 @@ namespace vke {
           .dstBinding = 1,
           .descriptorCount = 1,
           .descriptorType = vk::DescriptorType::eStorageImage,
-          .pImageInfo = &imageResource->getDescriptorImageInfo()
+          .pImageInfo = &imageResource.getDescriptorImageInfo()
         },
         m_cameraUniformRT->getDescriptorSet(2, descriptorSet, currentFrame),
         storageBuffer(3, &m_vertexBufferInfo),

--- a/source/components/renderingManager/renderer3D/RayTracer.h
+++ b/source/components/renderingManager/renderer3D/RayTracer.h
@@ -42,7 +42,7 @@ namespace vke {
     void doRayTracing(const RenderInfo* renderInfo,
                       const std::shared_ptr<PipelineManager>& pipelineManager,
                       const std::shared_ptr<LightingManager>& lightingManager,
-                      const std::shared_ptr<ImageResource>& imageResource,
+                      const ImageResource& imageResource,
                       const std::vector<std::shared_ptr<RenderObject>>& renderObjects,
                       const std::shared_ptr<Cloud>& cloud,
                       const glm::vec3& viewPosition,
@@ -105,7 +105,7 @@ namespace vke {
                                   const std::vector<uint32_t>& mergedIndices,
                                   const std::vector<MeshInfo>& meshInfos);
 
-    void updateRTDescriptorSets(const std::shared_ptr<ImageResource>& imageResource,
+    void updateRTDescriptorSets(const ImageResource& imageResource,
                                 uint32_t currentFrame);
 
     void updateRTDescriptorSetData(vk::Extent2D extent,

--- a/source/components/renderingManager/renderer3D/Renderer3D.cpp
+++ b/source/components/renderingManager/renderer3D/Renderer3D.cpp
@@ -102,7 +102,7 @@ namespace vke {
   void Renderer3D::doRayTracing(const RenderInfo* renderInfo,
                                 const std::shared_ptr<PipelineManager>& pipelineManager,
                                 const std::shared_ptr<LightingManager>& lightingManager,
-                                const std::shared_ptr<ImageResource>& imageResource) const
+                                const ImageResource& imageResource) const
   {
     m_rayTracer->doRayTracing(
       renderInfo,

--- a/source/components/renderingManager/renderer3D/Renderer3D.h
+++ b/source/components/renderingManager/renderer3D/Renderer3D.h
@@ -82,7 +82,7 @@ namespace vke {
     void doRayTracing(const RenderInfo* renderInfo,
                       const std::shared_ptr<PipelineManager>& pipelineManager,
                       const std::shared_ptr<LightingManager>& lightingManager,
-                      const std::shared_ptr<ImageResource>& imageResource) const;
+                      const ImageResource& imageResource) const;
 
     void createNewFrame();
 


### PR DESCRIPTION
This pull request refactors how image resources and render targets are managed, with a particular focus on improving the handling of shadow maps and ray tracing image resources. The changes streamline access to image resources, remove redundant methods, and enhance the flexibility and clarity of the rendering pipeline. The most important changes are grouped below by theme.

### Refactoring and Simplification of Image Resource Access

* Removed `getShadowMap()` and `getShadowMapView()` methods from the `Light` class, and updated all usages to access the shadow map image view directly through the `RenderTarget`'s `getDepthImageResource()` method. This centralizes image resource management and reduces redundancy. [[1]](diffhunk://#diff-d8613097ab2014eaaf1f4580c1d62f8a8df0e9c9e53eef7a1e35b8ee2a26cdb0L69-L78) [[2]](diffhunk://#diff-8c15d51bcd8fbf99c9d4a697345cc906e3301c827a833c1e37af1c41bf24c3f7L74-L77) [[3]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22L310-R312) [[4]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22L400-R402)
* Added new accessor methods in `RenderTarget` (`getColorImageResource`, `getDepthImageResource`, `getResolveImageResource`, `getRayTracingImageResource`) and removed the old `has*ImageResource` methods, simplifying the interface for accessing image resources. [[1]](diffhunk://#diff-9d81c0b449036297649110be5e5845e82972f7fb1ebdc1d6ee9f4703be0084b4L6-R59) [[2]](diffhunk://#diff-9d81c0b449036297649110be5e5845e82972f7fb1ebdc1d6ee9f4703be0084b4L41-L75) [[3]](diffhunk://#diff-d7a94d064bdd2a96d4d9c8569c4af037ac2af791ac085c8eb2ae6e0347ce4cfcL15-R24)

### Improved Render Target and Rendering Pipeline Management

* Refactored the `RenderTarget` constructor to support optional creation of ray tracing resources, and moved ray tracing image resource creation logic into `RenderTarget` itself. [[1]](diffhunk://#diff-9d81c0b449036297649110be5e5845e82972f7fb1ebdc1d6ee9f4703be0084b4L6-R59) [[2]](diffhunk://#diff-d7a94d064bdd2a96d4d9c8569c4af037ac2af791ac085c8eb2ae6e0347ce4cfcL15-R24) [[3]](diffhunk://#diff-d7a94d064bdd2a96d4d9c8569c4af037ac2af791ac085c8eb2ae6e0347ce4cfcR33-R41)
* Updated the rendering pipeline (`Renderer` class) to use the new `RenderTarget` interface, removing direct management of ray tracing image resources from `Renderer` and delegating it to `RenderTarget`. [[1]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL24-L63) [[2]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL251-L262) [[3]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL330-L351) [[4]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL313-R296)

### Rendering API and Internal Logic Adjustments

* Simplified and unified the begin rendering methods (`beginSwapchainRendering`, `beginOffscreenRendering`, `beginShadowRendering`, `beginMousePickingRendering`) to always use the render target's extent, removing the need to pass extents explicitly. [[1]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL91-R83) [[2]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL103) [[3]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL128-R119) [[4]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL139-R136) [[5]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL155-R147) [[6]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL168) [[7]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22L467-R469) [[8]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22L545-R547)
* Updated all ray tracing image transitions and copy operations to use the new accessors on the offscreen render target, further centralizing resource management. [[1]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL221-R212) [[2]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL415-R376) [[3]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL468-R429) [[4]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL521-R482)

These changes collectively improve the maintainability, flexibility, and clarity of the rendering and resource management subsystems.