### PR TITLE
Decouple Rendering Components and Simplify Rendering Logic

### DIFF
--- a/source/VulkanEngine.cpp
+++ b/source/VulkanEngine.cpp
@@ -124,7 +124,6 @@ namespace vke {
       m_logicalDevice,
       m_surface,
       m_window,
-      engineConfig.imGui.useDockspace,
       engineConfig.imGui.sceneViewName.c_str(),
       m_assetManager
     );

--- a/source/VulkanEngine.cpp
+++ b/source/VulkanEngine.cpp
@@ -129,7 +129,7 @@ namespace vke {
       m_assetManager
     );
 
-    m_lightingManager = std::make_shared<LightingManager>(m_logicalDevice, m_renderingManager->getRenderer());
+    m_lightingManager = std::make_shared<LightingManager>(m_logicalDevice);
 
     m_pipelineManager = std::make_shared<PipelineManager>(
       m_logicalDevice,

--- a/source/components/lighting/LightingManager.cpp
+++ b/source/components/lighting/LightingManager.cpp
@@ -10,7 +10,6 @@
 #include "../pipelines/pipelineManager/PipelineManager.h"
 #include "../pipelines/uniformBuffers/UniformBuffer.h"
 #include "../renderingManager/ImageResource.h"
-#include "../renderingManager/Renderer.h"
 #include "../renderingManager/RenderTarget.h"
 
 namespace {
@@ -465,7 +464,7 @@ namespace vke {
         .height = light->getShadowMapSize()
       };
 
-      Renderer::beginShadowRendering(commandBuffer, light);
+      beginShadowRendering(commandBuffer, light);
 
       vk::Viewport viewport {
         .x = 0.0f,
@@ -543,7 +542,7 @@ namespace vke {
         .height = light->getShadowMapSize()
       };
 
-      Renderer::beginShadowRendering(commandBuffer, light);
+      beginShadowRendering(commandBuffer, light);
 
       vk::Viewport viewport {
         .x = 0.0f,
@@ -660,5 +659,39 @@ namespace vke {
     {
       m_lightMetadataUniform->update(i, &lightMetadataUBO);
     }
+  }
+
+  void LightingManager::beginShadowRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
+                                             const std::shared_ptr<Light>& light)
+  {
+    static constexpr vk::ClearValue s_clearDepth = vk::ClearDepthStencilValue{
+      .depth = 1.0f,
+      .stencil = 0
+    };
+
+    const auto shadowMapRenderTarget = light->getShadowMapRenderTarget();
+
+    vk::RenderingAttachmentInfo depthRenderingAttachmentInfo {
+      .imageView = shadowMapRenderTarget->getDepthImageResource(0).getImageView(),
+      .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
+      .loadOp = vk::AttachmentLoadOp::eClear,
+      .storeOp = vk::AttachmentStoreOp::eStore,
+      .clearValue = s_clearDepth
+    };
+
+    constexpr uint32_t kCubemapFacesMask = 0x3Fu;
+    const vk::RenderingInfo renderingInfo {
+      .renderArea = {
+        .offset = {0, 0},
+        .extent = shadowMapRenderTarget->getExtent(),
+      },
+      .layerCount = 1,
+      .viewMask = light->getLightType() == LightType::pointLight ? kCubemapFacesMask : 0,
+      .colorAttachmentCount = 0,
+      .pColorAttachments = nullptr,
+      .pDepthAttachment = &depthRenderingAttachmentInfo,
+    };
+
+    commandBuffer->beginRendering(renderingInfo);
   }
 } // namespace vke

--- a/source/components/lighting/LightingManager.cpp
+++ b/source/components/lighting/LightingManager.cpp
@@ -92,9 +92,8 @@ namespace {
 
 namespace vke {
 
-  LightingManager::LightingManager(std::shared_ptr<LogicalDevice> logicalDevice,
-                                   std::shared_ptr<Renderer> renderer)
-    : m_logicalDevice(std::move(logicalDevice)), m_renderer(std::move(renderer))
+  LightingManager::LightingManager(std::shared_ptr<LogicalDevice> logicalDevice)
+    : m_logicalDevice(std::move(logicalDevice))
   {
     createCommandPool();
 
@@ -466,7 +465,7 @@ namespace vke {
         .height = light->getShadowMapSize()
       };
 
-      m_renderer->beginShadowRendering(commandBuffer, light);
+      Renderer::beginShadowRendering(commandBuffer, light);
 
       vk::Viewport viewport {
         .x = 0.0f,
@@ -544,7 +543,7 @@ namespace vke {
         .height = light->getShadowMapSize()
       };
 
-      m_renderer->beginShadowRendering(commandBuffer, light);
+      Renderer::beginShadowRendering(commandBuffer, light);
 
       vk::Viewport viewport {
         .x = 0.0f,

--- a/source/components/lighting/LightingManager.h
+++ b/source/components/lighting/LightingManager.h
@@ -112,6 +112,9 @@ namespace vke {
     [[nodiscard]] vk::DescriptorPool getDescriptorPool();
 
     void updateLightMetadataUniform() const;
+
+    static void beginShadowRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
+                                     const std::shared_ptr<Light>& light);
   };
 
 } // namespace vke

--- a/source/components/lighting/LightingManager.h
+++ b/source/components/lighting/LightingManager.h
@@ -19,8 +19,7 @@ namespace vke {
 
   class LightingManager {
   public:
-    LightingManager(std::shared_ptr<LogicalDevice> logicalDevice,
-                    std::shared_ptr<Renderer> renderer);
+    explicit LightingManager(std::shared_ptr<LogicalDevice> logicalDevice);
 
     [[nodiscard]] std::shared_ptr<Light> createPointLight(glm::vec3 position,
                                                           glm::vec3 color,

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -127,35 +127,6 @@ namespace vke {
     commandBuffer->beginRendering(renderingInfo);
   }
 
-  void Renderer::beginShadowRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                      const std::shared_ptr<Light>& light)
-  {
-    const auto shadowMapRenderTarget = light->getShadowMapRenderTarget();
-
-    vk::RenderingAttachmentInfo depthRenderingAttachmentInfo {
-      .imageView = shadowMapRenderTarget->getDepthImageResource(0).getImageView(),
-      .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
-      .loadOp = vk::AttachmentLoadOp::eClear,
-      .storeOp = vk::AttachmentStoreOp::eStore,
-      .clearValue = s_clearDepth
-    };
-
-    constexpr uint32_t kCubemapFacesMask = 0x3Fu;
-    const vk::RenderingInfo renderingInfo {
-      .renderArea = {
-        .offset = {0, 0},
-        .extent = shadowMapRenderTarget->getExtent(),
-      },
-      .layerCount = 1,
-      .viewMask = light->getLightType() == LightType::pointLight ? kCubemapFacesMask : 0,
-      .colorAttachmentCount = 0,
-      .pColorAttachments = nullptr,
-      .pDepthAttachment = &depthRenderingAttachmentInfo,
-    };
-
-    commandBuffer->beginRendering(renderingInfo);
-  }
-
   void Renderer::beginMousePickingRendering(const uint32_t currentFrame,
                                             const std::shared_ptr<CommandBuffer>& commandBuffer) const
   {

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -16,8 +16,6 @@ namespace vke {
   {
     createSampler();
 
-    createSwapchainRenderTarget(swapChain);
-
     createMousePickingRenderTarget(swapChain->getExtent());
   }
 
@@ -29,13 +27,6 @@ namespace vke {
   std::shared_ptr<RenderTarget> Renderer::getMousePickingRenderTarget() const
   {
     return m_mousePickingRenderTarget;
-  }
-
-  void Renderer::resetSwapchainRenderTarget(const std::shared_ptr<SwapChain>& swapChain)
-  {
-    m_swapchainRenderTarget.reset();
-
-    createSwapchainRenderTarget(swapChain);
   }
 
   void Renderer::resetOffscreenRenderTarget(const vk::Extent2D offscreenViewportExtent)
@@ -50,45 +41,6 @@ namespace vke {
     m_mousePickingRenderTarget.reset();
 
     createMousePickingRenderTarget(mousePickingExtent);
-  }
-
-  void Renderer::beginSwapchainRendering(const uint32_t imageIndex,
-                                         const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                         const std::shared_ptr<SwapChain>& swapChain) const
-  {
-    transitionSwapchainImagePreRender(commandBuffer, swapChain->getImages()[imageIndex]);
-
-    vk::RenderingAttachmentInfo colorRenderingAttachmentInfo {
-      .imageView = m_swapchainRenderTarget->getColorImageResource(imageIndex).getImageView(),
-      .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,
-      .resolveMode = vk::ResolveModeFlagBits::eAverage,
-      .resolveImageView = swapChain->getImageViews()[imageIndex],
-      .resolveImageLayout = vk::ImageLayout::eColorAttachmentOptimal,
-      .loadOp = vk::AttachmentLoadOp::eClear,
-      .storeOp = vk::AttachmentStoreOp::eStore,
-      .clearValue = s_clearColor
-    };
-
-    vk::RenderingAttachmentInfo depthRenderingAttachmentInfo {
-      .imageView = m_swapchainRenderTarget->getDepthImageResource(imageIndex).getImageView(),
-      .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
-      .loadOp = vk::AttachmentLoadOp::eClear,
-      .storeOp = vk::AttachmentStoreOp::eDontCare,
-      .clearValue = s_clearDepth
-    };
-
-    const vk::RenderingInfo renderingInfo {
-      .renderArea = {
-        .offset = {0, 0},
-        .extent = m_swapchainRenderTarget->getExtent(),
-      },
-      .layerCount = 1,
-      .colorAttachmentCount = 1,
-      .pColorAttachments = &colorRenderingAttachmentInfo,
-      .pDepthAttachment = &depthRenderingAttachmentInfo,
-    };
-
-    commandBuffer->beginRendering(renderingInfo);
   }
 
   void Renderer::beginOffscreenRendering(const uint32_t currentFrame,
@@ -161,15 +113,6 @@ namespace vke {
     commandBuffer->beginRendering(renderingInfo);
   }
 
-  void Renderer::endSwapchainRendering(const uint32_t imageIndex,
-                                       const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                       const std::shared_ptr<SwapChain>& swapChain)
-  {
-    commandBuffer->endRendering();
-
-    transitionSwapchainImagePostRender(commandBuffer, swapChain->getImages()[imageIndex]);
-  }
-
   void Renderer::beginRayTracingRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                           const uint32_t currentFrame) const
   {
@@ -233,20 +176,6 @@ namespace vke {
     m_sampler = m_logicalDevice->createSampler(samplerInfo);
   }
 
-  void Renderer::createSwapchainRenderTarget(const std::shared_ptr<SwapChain>& swapChain)
-  {
-    ImageResourceConfig imageResourceConfig {
-      .logicalDevice = m_logicalDevice,
-      .extent = swapChain->getExtent(),
-      .commandPool = m_commandPool,
-      .colorFormat = swapChain->getImageFormat(),
-      .depthFormat = m_logicalDevice->getPhysicalDevice()->findDepthFormat(),
-      .numSamples = m_logicalDevice->getPhysicalDevice()->getMsaaSamples()
-    };
-
-    m_swapchainRenderTarget = std::make_shared<RenderTarget>(imageResourceConfig, static_cast<uint32_t>(swapChain->getImages().size()));
-  }
-
   void Renderer::createOffscreenRenderTarget(const vk::Extent2D extent)
   {
     ImageResourceConfig imageResourceConfig {
@@ -279,66 +208,6 @@ namespace vke {
     };
 
     m_mousePickingRenderTarget = std::make_shared<RenderTarget>(imageResourceConfig, m_logicalDevice->getMaxFramesInFlight());
-  }
-
-  void Renderer::transitionSwapchainImagePreRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                                   const vk::Image image)
-  {
-    const vk::ImageMemoryBarrier imageMemoryBarrier {
-      .srcAccessMask = vk::AccessFlagBits::eNone,
-      .dstAccessMask = vk::AccessFlagBits::eColorAttachmentWrite,
-      .oldLayout = vk::ImageLayout::eUndefined,
-      .newLayout = vk::ImageLayout::eColorAttachmentOptimal,
-      .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
-      .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
-      .image = image,
-      .subresourceRange = {
-        .aspectMask = vk::ImageAspectFlagBits::eColor,
-        .baseMipLevel = 0,
-        .levelCount = 1,
-        .baseArrayLayer = 0,
-        .layerCount = 1,
-      }
-    };
-
-    commandBuffer->pipelineBarrier(
-      vk::PipelineStageFlagBits::eTopOfPipe,
-      vk::PipelineStageFlagBits::eColorAttachmentOutput,
-      {},
-      {},
-      {},
-      { imageMemoryBarrier }
-    );
-  }
-
-  void Renderer::transitionSwapchainImagePostRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                                    const vk::Image image)
-  {
-    const vk::ImageMemoryBarrier imageMemoryBarrier {
-      .srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite,
-      .dstAccessMask = vk::AccessFlagBits::eNone,
-      .oldLayout = vk::ImageLayout::eColorAttachmentOptimal,
-      .newLayout = vk::ImageLayout::ePresentSrcKHR,
-      .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
-      .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
-      .image = image,
-      .subresourceRange = {
-        .aspectMask = vk::ImageAspectFlagBits::eColor,
-        .baseMipLevel = 0,
-        .levelCount = 1,
-        .baseArrayLayer = 0,
-        .layerCount = 1,
-      }
-    };
-
-    commandBuffer->pipelineBarrier(
-      vk::PipelineStageFlagBits::eColorAttachmentOutput,
-      vk::PipelineStageFlagBits::eBottomOfPipe,
-      {},
-      {},
-      {},
-      { imageMemoryBarrier }
-    );
   }
 
   void Renderer::transitionRayTracingImagePreCopy(const std::shared_ptr<CommandBuffer>& commandBuffer,

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -5,18 +5,14 @@
 #include "../lighting/lights/Light.h"
 #include "../logicalDevice/LogicalDevice.h"
 #include "../physicalDevice/PhysicalDevice.h"
-#include "../window/SwapChain.h"
 
 namespace vke {
 
   Renderer::Renderer(std::shared_ptr<LogicalDevice> logicalDevice,
-                     const std::shared_ptr<SwapChain>& swapChain,
                      const vk::CommandPool commandPool)
     : m_logicalDevice(std::move(logicalDevice)), m_commandPool(commandPool)
   {
     createSampler();
-
-    createMousePickingRenderTarget(swapChain->getExtent());
   }
 
   std::shared_ptr<RenderTarget> Renderer::getOffscreenRenderTarget() const

--- a/source/components/renderingManager/Renderer.cpp
+++ b/source/components/renderingManager/Renderer.cpp
@@ -29,18 +29,13 @@ namespace vke {
     return m_mousePickingRenderTarget;
   }
 
-  void Renderer::resetOffscreenRenderTarget(const vk::Extent2D offscreenViewportExtent)
+  void Renderer::recreateRenderTargets(const vk::Extent2D extent)
   {
     m_offscreenRenderTarget.reset();
-
-    createOffscreenRenderTarget(offscreenViewportExtent);
-  }
-
-  void Renderer::resetMousePickingRenderTarget(const vk::Extent2D mousePickingExtent)
-  {
     m_mousePickingRenderTarget.reset();
 
-    createMousePickingRenderTarget(mousePickingExtent);
+    createOffscreenRenderTarget(extent);
+    createMousePickingRenderTarget(extent);
   }
 
   void Renderer::beginOffscreenRendering(const uint32_t currentFrame,

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -36,9 +36,6 @@ namespace vke {
     void beginOffscreenRendering(uint32_t currentFrame,
                                  const std::shared_ptr<CommandBuffer>& commandBuffer) const;
 
-    static void beginShadowRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                     const std::shared_ptr<Light>& light);
-
     void beginMousePickingRendering(uint32_t currentFrame,
                                     const std::shared_ptr<CommandBuffer>& commandBuffer) const;
 

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -8,15 +8,12 @@
 namespace vke {
 
   class CommandBuffer;
-  class Light;
   class LogicalDevice;
   class RenderTarget;
-  class SwapChain;
 
   class Renderer {
   public:
     explicit Renderer(std::shared_ptr<LogicalDevice> logicalDevice,
-                      const std::shared_ptr<SwapChain>& swapChain,
                       vk::CommandPool commandPool);
 
     [[nodiscard]] std::shared_ptr<RenderTarget> getOffscreenRenderTarget() const;

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -23,25 +23,15 @@ namespace vke {
 
     [[nodiscard]] std::shared_ptr<RenderTarget> getMousePickingRenderTarget() const;
 
-    void resetSwapchainRenderTarget(const std::shared_ptr<SwapChain>& swapChain);
-
     void resetOffscreenRenderTarget(vk::Extent2D offscreenViewportExtent);
 
     void resetMousePickingRenderTarget(vk::Extent2D mousePickingExtent);
-
-    void beginSwapchainRendering(uint32_t imageIndex,
-                                 const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                 const std::shared_ptr<SwapChain>& swapChain) const;
 
     void beginOffscreenRendering(uint32_t currentFrame,
                                  const std::shared_ptr<CommandBuffer>& commandBuffer) const;
 
     void beginMousePickingRendering(uint32_t currentFrame,
                                     const std::shared_ptr<CommandBuffer>& commandBuffer) const;
-
-    static void endSwapchainRendering(uint32_t imageIndex,
-                                      const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                      const std::shared_ptr<SwapChain>& swapChain);
 
     void beginRayTracingRendering(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                   uint32_t currentFrame) const;
@@ -62,25 +52,15 @@ namespace vke {
 
     std::shared_ptr<RenderTarget> m_offscreenRenderTarget;
 
-    std::shared_ptr<RenderTarget> m_swapchainRenderTarget;
-
     std::shared_ptr<RenderTarget> m_mousePickingRenderTarget;
 
     vk::raii::Sampler m_sampler = nullptr;
 
     void createSampler();
 
-    void createSwapchainRenderTarget(const std::shared_ptr<SwapChain>& swapChain);
-
     void createOffscreenRenderTarget(vk::Extent2D extent);
 
     void createMousePickingRenderTarget(vk::Extent2D extent);
-    
-    static void transitionSwapchainImagePreRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                                  vk::Image image);
-
-    static void transitionSwapchainImagePostRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                                   vk::Image image);
 
     void transitionRayTracingImagePreCopy(const std::shared_ptr<CommandBuffer>& commandBuffer,
                                           uint32_t currentFrame) const;

--- a/source/components/renderingManager/Renderer.h
+++ b/source/components/renderingManager/Renderer.h
@@ -23,9 +23,7 @@ namespace vke {
 
     [[nodiscard]] std::shared_ptr<RenderTarget> getMousePickingRenderTarget() const;
 
-    void resetOffscreenRenderTarget(vk::Extent2D offscreenViewportExtent);
-
-    void resetMousePickingRenderTarget(vk::Extent2D mousePickingExtent);
+    void recreateRenderTargets(vk::Extent2D extent);
 
     void beginOffscreenRendering(uint32_t currentFrame,
                                  const std::shared_ptr<CommandBuffer>& commandBuffer) const;

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -121,23 +121,13 @@ namespace vke {
 
     m_swapChain = std::make_shared<SwapChain>(m_logicalDevice, m_window, m_surface, m_commandPool);
 
-    if (m_shouldRenderOffscreen)
+    if (m_offscreenViewportExtent.width == 0 || m_offscreenViewportExtent.height == 0)
     {
-      if (m_offscreenViewportExtent.width == 0 || m_offscreenViewportExtent.height == 0)
-      {
-        return;
-      }
-
-      m_renderer->resetOffscreenRenderTarget(m_offscreenViewportExtent);
-
-      m_renderer->resetMousePickingRenderTarget(m_offscreenViewportExtent);
-      m_renderer3D->getMousePicker()->setViewportExtent(m_offscreenViewportExtent);
+      return;
     }
-    else
-    {
-      m_renderer->resetMousePickingRenderTarget(m_swapChain->getExtent());
-      m_renderer3D->getMousePicker()->setViewportExtent(m_swapChain->getExtent());
-    }
+
+    m_renderer->recreateRenderTargets(m_offscreenViewportExtent);
+    m_renderer3D->getMousePicker()->setViewportExtent(m_offscreenViewportExtent);
   }
 
   void RenderingManager::createNewFrame() const
@@ -214,9 +204,7 @@ namespace vke {
 
       m_logicalDevice->waitIdle();
 
-      m_renderer->resetOffscreenRenderTarget(m_offscreenViewportExtent);
-
-      m_renderer->resetMousePickingRenderTarget(m_offscreenViewportExtent);
+      m_renderer->recreateRenderTargets(m_offscreenViewportExtent);
       m_renderer3D->getMousePicker()->setViewportExtent(m_offscreenViewportExtent);
     }
 

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -40,7 +40,7 @@ namespace vke {
     m_offscreenCommandBuffer = std::make_shared<CommandBuffer>(m_logicalDevice, m_commandPool);
     m_swapchainCommandBuffer = std::make_shared<CommandBuffer>(m_logicalDevice, m_commandPool);
 
-    m_swapChain = std::make_shared<SwapChain>(m_logicalDevice, m_window, m_surface);
+    m_swapChain = std::make_shared<SwapChain>(m_logicalDevice, m_window, m_surface, m_commandPool);
 
     m_renderer = std::make_shared<Renderer>(m_logicalDevice, m_swapChain, m_commandPool);
 
@@ -119,9 +119,7 @@ namespace vke {
 
     m_logicalDevice->getPhysicalDevice()->updateSwapChainSupportDetails();
 
-    m_swapChain = std::make_shared<SwapChain>(m_logicalDevice, m_window, m_surface);
-
-    m_renderer->resetSwapchainRenderTarget(m_swapChain);
+    m_swapChain = std::make_shared<SwapChain>(m_logicalDevice, m_window, m_surface, m_commandPool);
 
     if (m_shouldRenderOffscreen)
     {
@@ -368,7 +366,7 @@ namespace vke {
       };
       renderInfo.commandBuffer->setScissor(scissor);
 
-      m_renderer->beginSwapchainRendering(imageIndex, renderInfo.commandBuffer, m_swapChain);
+      m_swapChain->beginRendering(imageIndex, renderInfo.commandBuffer);
 
       if (!m_shouldRenderOffscreen)
       {
@@ -387,7 +385,7 @@ namespace vke {
 
       ImGuiInstance::render(renderInfo.commandBuffer);
 
-      m_renderer->endSwapchainRendering(imageIndex, renderInfo.commandBuffer, m_swapChain);
+      m_swapChain->endRendering(imageIndex, renderInfo.commandBuffer);
     });
 
     m_logicalDevice->submitSwapchainCommandBuffer(currentFrame, m_swapchainCommandBuffer->getCommandBuffer());

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -98,11 +98,6 @@ namespace vke {
     }
   }
 
-  std::shared_ptr<Renderer> RenderingManager::getRenderer() const
-  {
-    return m_renderer;
-  }
-
   bool RenderingManager::isSceneFocused() const
   {
     return m_sceneIsFocused || !m_shouldRenderOffscreen;

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -42,7 +42,7 @@ namespace vke {
 
     m_swapChain = std::make_shared<SwapChain>(m_logicalDevice, m_window, m_surface, m_commandPool);
 
-    m_renderer = std::make_shared<Renderer>(m_logicalDevice, m_swapChain, m_commandPool);
+    m_renderer = std::make_shared<Renderer>(m_logicalDevice, m_commandPool);
 
     m_framebufferResizeEventListener = m_window->on<FramebufferResizeEvent>([this]([[maybe_unused]] const FramebufferResizeEvent& e) {
       m_framebufferResized = true;
@@ -312,7 +312,9 @@ namespace vke {
 
     m_logicalDevice->submitOffscreenCommandBuffer(currentFrame, m_offscreenCommandBuffer->getCommandBuffer());
 
-    if (m_shouldRenderOffscreen)
+    if (m_shouldRenderOffscreen &&
+        m_offscreenViewportExtent.width != 0 &&
+        m_offscreenViewportExtent.height != 0)
     {
       m_logicalDevice->waitForOffscreenFence(currentFrame);
       m_renderer3D->handleRenderedMousePickingImage(m_renderer->getMousePickingRenderTarget()->getColorImageResource(0).getImage());

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -201,8 +201,7 @@ namespace vke {
       m_renderer3D->getMousePicker()->setViewportExtent(m_offscreenViewportExtent);
     }
 
-    m_offscreenViewportPos = ImGui::GetCursorScreenPos();
-    m_renderer3D->getMousePicker()->setViewportPos(m_offscreenViewportPos);
+    m_renderer3D->getMousePicker()->setViewportPos(ImGui::GetCursorScreenPos());
 
     const auto offscreenImageDescriptorSet = m_renderer->getOffscreenRenderTarget()->getResolveImageResource(currentFrame).getDescriptorSet();
 

--- a/source/components/renderingManager/RenderingManager.cpp
+++ b/source/components/renderingManager/RenderingManager.cpp
@@ -22,13 +22,11 @@ namespace vke {
   RenderingManager::RenderingManager(std::shared_ptr<LogicalDevice> logicalDevice,
                                      std::shared_ptr<Surface> surface,
                                      std::shared_ptr<Window> window,
-                                     const bool shouldRenderOffscreen,
                                      std::string sceneViewName,
                                      const std::shared_ptr<AssetManager>& assetManager)
     : m_logicalDevice(std::move(logicalDevice)),
       m_surface(std::move(surface)),
       m_window(std::move(window)),
-      m_shouldRenderOffscreen(shouldRenderOffscreen),
       m_sceneViewName(std::move(sceneViewName)),
       m_renderer2D(std::make_shared<Renderer2D>(assetManager)),
       m_rayTracingEnabled(m_logicalDevice->getPhysicalDevice()->supportsRayTracing())
@@ -83,7 +81,7 @@ namespace vke {
 
     recordOffscreenCommandBuffer(pipelineManager, lightingManager, currentFrame);
 
-    recordSwapchainCommandBuffer(pipelineManager, lightingManager, currentFrame, imageIndex);
+    recordSwapchainCommandBuffer(currentFrame, imageIndex);
 
     result = m_logicalDevice->queuePresent(currentFrame, m_swapChain->getSwapChain(), &imageIndex);
 
@@ -100,7 +98,7 @@ namespace vke {
 
   bool RenderingManager::isSceneFocused() const
   {
-    return m_sceneIsFocused || !m_shouldRenderOffscreen;
+    return m_sceneIsFocused;
   }
 
   void RenderingManager::recreateSwapChain()
@@ -174,11 +172,6 @@ namespace vke {
 
   void RenderingManager::renderGuiScene(const uint32_t currentFrame)
   {
-    if (!m_shouldRenderOffscreen)
-    {
-      return;
-    }
-
     ImGui::Begin(m_sceneViewName.c_str());
 
     m_sceneIsFocused = ImGui::IsWindowFocused();
@@ -253,7 +246,21 @@ namespace vke {
 
       m_renderer3D->render(&renderInfo, pipelineManager, lightingManager);
 
-      resetDepthBuffer(m_offscreenCommandBuffer, m_offscreenViewportExtent);
+      constexpr vk::ClearAttachment clearAttachment{
+        .aspectMask = vk::ImageAspectFlagBits::eDepth,
+        .clearValue = vk::ClearValue{ {1.0f, 0} }
+      };
+
+      const vk::ClearRect clearRect{
+        .rect = {
+          .offset = { 0, 0 },
+          .extent = renderInfo.extent
+        },
+        .baseArrayLayer = 0,
+        .layerCount = 1
+      };
+
+      renderInfo.commandBuffer->clearAttachments({ clearAttachment }, { clearRect });
 
       RenderInfo renderInfo2D = renderInfo;
       renderInfo2D.extent = vk::Extent2D{
@@ -281,8 +288,7 @@ namespace vke {
       };
 
       if (renderInfo.extent.width == 0 ||
-          renderInfo.extent.height == 0 ||
-          !m_shouldRenderOffscreen)
+          renderInfo.extent.height == 0)
       {
         return;
       }
@@ -312,8 +318,7 @@ namespace vke {
 
     m_logicalDevice->submitOffscreenCommandBuffer(currentFrame, m_offscreenCommandBuffer->getCommandBuffer());
 
-    if (m_shouldRenderOffscreen &&
-        m_offscreenViewportExtent.width != 0 &&
+    if (m_offscreenViewportExtent.width != 0 &&
         m_offscreenViewportExtent.height != 0)
     {
       m_logicalDevice->waitForOffscreenFence(currentFrame);
@@ -321,16 +326,14 @@ namespace vke {
     }
   }
 
-  void RenderingManager::recordSwapchainCommandBuffer(const std::shared_ptr<PipelineManager>& pipelineManager,
-                                                      const std::shared_ptr<LightingManager>& lightingManager,
-                                                      uint32_t currentFrame,
+  void RenderingManager::recordSwapchainCommandBuffer(uint32_t currentFrame,
                                                       const uint32_t imageIndex) const
   {
     m_swapchainCommandBuffer->setCurrentFrame(currentFrame);
 
     m_swapchainCommandBuffer->resetCommandBuffer();
 
-    m_swapchainCommandBuffer->record([this, pipelineManager, lightingManager, currentFrame, imageIndex]
+    m_swapchainCommandBuffer->record([this, currentFrame, imageIndex]
     {
       const RenderInfo renderInfo {
         .commandBuffer = m_swapchainCommandBuffer,
@@ -358,47 +361,12 @@ namespace vke {
 
       m_swapChain->beginRendering(imageIndex, renderInfo.commandBuffer);
 
-      if (!m_shouldRenderOffscreen)
-      {
-        m_renderer3D->render(&renderInfo, pipelineManager, lightingManager);
-
-        resetDepthBuffer(m_swapchainCommandBuffer, m_swapChain->getExtent());
-
-        RenderInfo renderInfo2D = renderInfo;
-        renderInfo2D.extent = vk::Extent2D{
-          .width = static_cast<uint32_t>(static_cast<float>(renderInfo.extent.width) / m_window->getContentScale()),
-          .height = static_cast<uint32_t>(static_cast<float>(renderInfo.extent.height) / m_window->getContentScale()),
-        };
-
-        m_renderer2D->render(&renderInfo2D, pipelineManager);
-      }
-
       ImGuiInstance::render(renderInfo.commandBuffer);
 
       m_swapChain->endRendering(imageIndex, renderInfo.commandBuffer);
     });
 
     m_logicalDevice->submitSwapchainCommandBuffer(currentFrame, m_swapchainCommandBuffer->getCommandBuffer());
-  }
-
-  void RenderingManager::resetDepthBuffer(const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                          const vk::Extent2D extent)
-  {
-    constexpr vk::ClearAttachment clearAttachment{
-      .aspectMask = vk::ImageAspectFlagBits::eDepth,
-      .clearValue = vk::ClearValue{ {1.0f, 0} }
-    };
-
-    const vk::ClearRect clearRect{
-      .rect = {
-        .offset = { 0, 0 },
-        .extent = extent
-      },
-      .baseArrayLayer = 0,
-      .layerCount = 1
-    };
-
-    commandBuffer->clearAttachments({ clearAttachment }, { clearRect });
   }
 
   void RenderingManager::createCommandPool()

--- a/source/components/renderingManager/RenderingManager.h
+++ b/source/components/renderingManager/RenderingManager.h
@@ -78,7 +78,7 @@ namespace vke {
 
     bool m_sceneIsFocused = false;
 
-    vk::Extent2D m_offscreenViewportExtent{};
+    vk::Extent2D m_offscreenViewportExtent{0, 0};
 
     ImVec2 m_offscreenViewportPos{0, 0};
 

--- a/source/components/renderingManager/RenderingManager.h
+++ b/source/components/renderingManager/RenderingManager.h
@@ -27,7 +27,6 @@ namespace vke {
     RenderingManager(std::shared_ptr<LogicalDevice> logicalDevice,
                      std::shared_ptr<Surface> surface,
                      std::shared_ptr<Window> window,
-                     bool shouldRenderOffscreen,
                      std::string sceneViewName,
                      const std::shared_ptr<AssetManager>& assetManager);
 
@@ -72,8 +71,6 @@ namespace vke {
 
     std::shared_ptr<SwapChain> m_swapChain;
 
-    bool m_shouldRenderOffscreen;
-
     bool m_framebufferResized = false;
 
     bool m_sceneIsFocused = false;
@@ -98,13 +95,8 @@ namespace vke {
                                       const std::shared_ptr<LightingManager>& lightingManager,
                                       uint32_t currentFrame) const;
 
-    void recordSwapchainCommandBuffer(const std::shared_ptr<PipelineManager>& pipelineManager,
-                                      const std::shared_ptr<LightingManager>& lightingManager,
-                                      uint32_t currentFrame,
+    void recordSwapchainCommandBuffer(uint32_t currentFrame,
                                       uint32_t imageIndex) const;
-
-    static void resetDepthBuffer(const std::shared_ptr<CommandBuffer>& commandBuffer,
-                                 vk::Extent2D extent);
 
     void createCommandPool();
   };

--- a/source/components/renderingManager/RenderingManager.h
+++ b/source/components/renderingManager/RenderingManager.h
@@ -77,8 +77,6 @@ namespace vke {
 
     vk::Extent2D m_offscreenViewportExtent{0, 0};
 
-    ImVec2 m_offscreenViewportPos{0, 0};
-
     std::string m_sceneViewName;
 
     std::shared_ptr<Renderer2D> m_renderer2D;

--- a/source/components/renderingManager/RenderingManager.h
+++ b/source/components/renderingManager/RenderingManager.h
@@ -37,8 +37,6 @@ namespace vke {
                      const std::shared_ptr<LightingManager>& lightingManager,
                      uint32_t currentFrame);
 
-    [[nodiscard]] std::shared_ptr<Renderer> getRenderer() const;
-
     [[nodiscard]] bool isSceneFocused() const;
 
     void recreateSwapChain();

--- a/source/components/window/SwapChain.cpp
+++ b/source/components/window/SwapChain.cpp
@@ -1,8 +1,10 @@
 #include "SwapChain.h"
 #include "Surface.h"
 #include "Window.h"
+#include "../commandBuffer/CommandBuffer.h"
 #include "../logicalDevice/LogicalDevice.h"
 #include "../physicalDevice/PhysicalDevice.h"
+#include "../renderingManager/RenderTarget.h"
 #include "../../utilities/Images.h"
 #include <limits>
 #include <algorithm>
@@ -11,11 +13,14 @@ namespace vke {
 
   SwapChain::SwapChain(const std::shared_ptr<LogicalDevice>& logicalDevice,
                        const std::shared_ptr<Window>& window,
-                       const std::shared_ptr<Surface>& surface)
+                       const std::shared_ptr<Surface>& surface,
+                       const vk::CommandPool commandPool)
   {
     createSwapChain(logicalDevice, window, surface);
 
     createImageViews(logicalDevice);
+
+    createRenderTarget(logicalDevice, commandPool);
   }
 
   vk::SurfaceFormatKHR SwapChain::chooseSwapSurfaceFormat(const std::vector<vk::SurfaceFormatKHR>& availableFormats)
@@ -142,6 +147,81 @@ namespace vke {
     }
   }
 
+  void SwapChain::createRenderTarget(const std::shared_ptr<LogicalDevice>& logicalDevice,
+                                              const vk::CommandPool commandPool)
+  {
+    ImageResourceConfig imageResourceConfig {
+      .logicalDevice = logicalDevice,
+      .extent = m_swapChainExtent,
+      .commandPool = commandPool,
+      .colorFormat = m_swapChainImageFormat,
+      .depthFormat = logicalDevice->getPhysicalDevice()->findDepthFormat(),
+      .numSamples = logicalDevice->getPhysicalDevice()->getMsaaSamples()
+    };
+
+    m_swapchainRenderTarget = std::make_shared<RenderTarget>(imageResourceConfig, static_cast<uint32_t>(m_swapChainImages.size()));
+  }
+
+  void SwapChain::transitionImagePreRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
+                                           const vk::Image image)
+  {
+    const vk::ImageMemoryBarrier imageMemoryBarrier {
+      .srcAccessMask = vk::AccessFlagBits::eNone,
+      .dstAccessMask = vk::AccessFlagBits::eColorAttachmentWrite,
+      .oldLayout = vk::ImageLayout::eUndefined,
+      .newLayout = vk::ImageLayout::eColorAttachmentOptimal,
+      .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
+      .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
+      .image = image,
+      .subresourceRange = {
+        .aspectMask = vk::ImageAspectFlagBits::eColor,
+        .baseMipLevel = 0,
+        .levelCount = 1,
+        .baseArrayLayer = 0,
+        .layerCount = 1,
+      }
+    };
+
+    commandBuffer->pipelineBarrier(
+      vk::PipelineStageFlagBits::eTopOfPipe,
+      vk::PipelineStageFlagBits::eColorAttachmentOutput,
+      {},
+      {},
+      {},
+      { imageMemoryBarrier }
+    );
+  }
+
+  void SwapChain::transitionImagePostRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
+                                            const vk::Image image)
+  {
+    const vk::ImageMemoryBarrier imageMemoryBarrier {
+      .srcAccessMask = vk::AccessFlagBits::eColorAttachmentWrite,
+      .dstAccessMask = vk::AccessFlagBits::eNone,
+      .oldLayout = vk::ImageLayout::eColorAttachmentOptimal,
+      .newLayout = vk::ImageLayout::ePresentSrcKHR,
+      .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
+      .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
+      .image = image,
+      .subresourceRange = {
+        .aspectMask = vk::ImageAspectFlagBits::eColor,
+        .baseMipLevel = 0,
+        .levelCount = 1,
+        .baseArrayLayer = 0,
+        .layerCount = 1,
+      }
+    };
+
+    commandBuffer->pipelineBarrier(
+      vk::PipelineStageFlagBits::eColorAttachmentOutput,
+      vk::PipelineStageFlagBits::eBottomOfPipe,
+      {},
+      {},
+      {},
+      { imageMemoryBarrier }
+    );
+  }
+
   vk::Format SwapChain::getImageFormat() const
   {
     return m_swapChainImageFormat;
@@ -165,6 +245,58 @@ namespace vke {
   const std::vector<vk::Image>& SwapChain::getImages() const
   {
     return m_swapChainImages;
+  }
+
+  void SwapChain::beginRendering(const uint32_t imageIndex,
+                                 const std::shared_ptr<CommandBuffer>& commandBuffer) const
+  {
+    static constexpr vk::ClearValue s_clearColor = vk::ClearColorValue(0.0f, 0.0f, 0.0f, 1.0f);
+    static constexpr vk::ClearValue s_clearDepth = vk::ClearDepthStencilValue{
+      .depth = 1.0f,
+      .stencil = 0
+    };
+
+    transitionImagePreRender(commandBuffer, m_swapChainImages.at(imageIndex));
+
+    vk::RenderingAttachmentInfo colorRenderingAttachmentInfo {
+      .imageView = m_swapchainRenderTarget->getColorImageResource(imageIndex).getImageView(),
+      .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,
+      .resolveMode = vk::ResolveModeFlagBits::eAverage,
+      .resolveImageView = m_swapChainImageViews.at(imageIndex),
+      .resolveImageLayout = vk::ImageLayout::eColorAttachmentOptimal,
+      .loadOp = vk::AttachmentLoadOp::eClear,
+      .storeOp = vk::AttachmentStoreOp::eStore,
+      .clearValue = s_clearColor
+    };
+
+    vk::RenderingAttachmentInfo depthRenderingAttachmentInfo {
+      .imageView = m_swapchainRenderTarget->getDepthImageResource(imageIndex).getImageView(),
+      .imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
+      .loadOp = vk::AttachmentLoadOp::eClear,
+      .storeOp = vk::AttachmentStoreOp::eDontCare,
+      .clearValue = s_clearDepth
+    };
+
+    const vk::RenderingInfo renderingInfo {
+      .renderArea = {
+        .offset = {0, 0},
+        .extent = m_swapchainRenderTarget->getExtent(),
+      },
+      .layerCount = 1,
+      .colorAttachmentCount = 1,
+      .pColorAttachments = &colorRenderingAttachmentInfo,
+      .pDepthAttachment = &depthRenderingAttachmentInfo,
+    };
+
+    commandBuffer->beginRendering(renderingInfo);
+  }
+
+  void SwapChain::endRendering(const uint32_t imageIndex,
+                               const std::shared_ptr<CommandBuffer>& commandBuffer) const
+  {
+    commandBuffer->endRendering();
+
+    transitionImagePostRender(commandBuffer, m_swapChainImages.at(imageIndex));
   }
 
 } // namespace vke

--- a/source/components/window/SwapChain.h
+++ b/source/components/window/SwapChain.h
@@ -7,7 +7,9 @@
 
 namespace vke {
 
+  class CommandBuffer;
   class LogicalDevice;
+  class RenderTarget;
   class Surface;
   class Window;
 
@@ -15,7 +17,8 @@ namespace vke {
   public:
     SwapChain(const std::shared_ptr<LogicalDevice>& logicalDevice,
               const std::shared_ptr<Window>& window,
-              const std::shared_ptr<Surface>& surface);
+              const std::shared_ptr<Surface>& surface,
+              vk::CommandPool commandPool);
 
     [[nodiscard]] vk::Format getImageFormat() const;
 
@@ -27,12 +30,20 @@ namespace vke {
 
     [[nodiscard]] const std::vector<vk::Image>& getImages() const;
 
+    void beginRendering(uint32_t imageIndex,
+                        const std::shared_ptr<CommandBuffer>& commandBuffer) const;
+
+    void endRendering(uint32_t imageIndex,
+                      const std::shared_ptr<CommandBuffer>& commandBuffer) const;
+
   private:
     vk::raii::SwapchainKHR m_swapchain = nullptr;
     std::vector<vk::Image> m_swapChainImages;
     vk::Format m_swapChainImageFormat = vk::Format::eUndefined;
     vk::Extent2D m_swapChainExtent{};
     std::vector<vk::raii::ImageView> m_swapChainImageViews;
+
+    std::shared_ptr<RenderTarget> m_swapchainRenderTarget;
 
     static vk::SurfaceFormatKHR chooseSwapSurfaceFormat(const std::vector<vk::SurfaceFormatKHR>& availableFormats);
 
@@ -48,6 +59,15 @@ namespace vke {
                          const std::shared_ptr<Surface>& surface);
 
     void createImageViews(const std::shared_ptr<LogicalDevice>& logicalDevice);
+
+    void createRenderTarget(const std::shared_ptr<LogicalDevice>& logicalDevice,
+                                     vk::CommandPool commandPool);
+
+    static void transitionImagePreRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
+                                                  vk::Image image);
+
+    static void transitionImagePostRender(const std::shared_ptr<CommandBuffer>& commandBuffer,
+                                                   vk::Image image);
   };
 
 } // namespace vke


### PR DESCRIPTION
This pull request refactors the rendering and lighting management subsystems to simplify dependencies, remove unnecessary code, and improve modularity. The most significant changes are the decoupling of `LightingManager` from the `Renderer`, the removal of swapchain-specific logic from the `Renderer`, and the consolidation of render target recreation logic.

**Lighting and Rendering Decoupling:**

* `LightingManager` no longer depends on `Renderer`, and its constructor now only requires a `LogicalDevice`. Shadow rendering logic has been moved into a new static method within `LightingManager` (`beginShadowRendering`). [[1]](diffhunk://#diff-f6d438ac8970e51954493ef322418756e38859c4854de0265beb1f319e41b232L127-R131) [[2]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22L13) [[3]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22L95-R95) [[4]](diffhunk://#diff-15ca0fc21f83da6af3ee096ff26a64cdd379180ede5385d79b82cc6a6f12c676L22-R22) [[5]](diffhunk://#diff-15ca0fc21f83da6af3ee096ff26a64cdd379180ede5385d79b82cc6a6f12c676R115-R117) [[6]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22L469-R467) [[7]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22L547-R545) [[8]](diffhunk://#diff-b5dbae204df098a250632a79ffea51dd54d4199c2e54cee1f0acc0eacf7f7b22R663-R696)

**Renderer Simplification and Swapchain Logic Removal:**

* The `Renderer` class no longer manages swapchain render targets or transitions. All swapchain-specific methods and members have been removed, and the constructor no longer takes a `SwapChain`. [[1]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL8-L21) [[2]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL34-R34) [[3]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL130-L158) [[4]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL193-L201) [[5]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL265-L278) [[6]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL313-L372) [[7]](diffhunk://#diff-ef208fb18c0751de5450913c03aedeedc455bb79eed14da9e2ffe7353b007ea8L11-L48) [[8]](diffhunk://#diff-ef208fb18c0751de5450913c03aedeedc455bb79eed14da9e2ffe7353b007ea8L68-L87)

**Render Target Recreation Consolidation:**

* A new method `recreateRenderTargets` in `Renderer` replaces multiple reset methods, handling offscreen and mouse picking render targets in one place. [[1]](diffhunk://#diff-75354e60bfd80f3f66fae05ed1a8aceab45d0d96580f8a3bd513a109078f033bL34-R34) [[2]](diffhunk://#diff-ef208fb18c0751de5450913c03aedeedc455bb79eed14da9e2ffe7353b007ea8L11-L48)

**RenderingManager Adjustments:**

* `RenderingManager` no longer tracks whether to render offscreen or not; related logic and members are removed. It now always recreates render targets with the current viewport extent. The dependency on `Renderer` is simplified, and the swapchain is now created with an additional `commandPool` parameter. [[1]](diffhunk://#diff-def7951aba553f067fb3b24a9973128c6673a4d9d66a68c865a23749d7611129L25-L31) [[2]](diffhunk://#diff-def7951aba553f067fb3b24a9973128c6673a4d9d66a68c865a23749d7611129L43-R43) [[3]](diffhunk://#diff-def7951aba553f067fb3b24a9973128c6673a4d9d66a68c865a23749d7611129L86-R84) [[4]](diffhunk://#diff-def7951aba553f067fb3b24a9973128c6673a4d9d66a68c865a23749d7611129L101-R101) [[5]](diffhunk://#diff-def7951aba553f067fb3b24a9973128c6673a4d9d66a68c865a23749d7611129L127-L148)

These changes collectively streamline the rendering pipeline, reduce coupling, and make the codebase easier to maintain and extend.