### PR TITLE
Separate Sampler and SampledImage pool sizes for ImGui textures

### DIFF
--- a/source/components/imGui/ImGuiInstance.cpp
+++ b/source/components/imGui/ImGuiInstance.cpp
@@ -217,8 +217,9 @@ namespace vke {
   void ImGuiInstance::createDescriptorPool(const std::shared_ptr<LogicalDevice>& logicalDevice,
                                            const uint32_t maxImGuiTextures)
   {
-    const std::array<vk::DescriptorPoolSize, 1> poolSizes {{
-      {vk::DescriptorType::eCombinedImageSampler, logicalDevice->getMaxFramesInFlight() * maxImGuiTextures}
+    const std::array<vk::DescriptorPoolSize, 2> poolSizes {{
+      {vk::DescriptorType::eSampler, logicalDevice->getMaxFramesInFlight() * maxImGuiTextures},
+      {vk::DescriptorType::eSampledImage, logicalDevice->getMaxFramesInFlight() * maxImGuiTextures}
     }};
 
     const vk::DescriptorPoolCreateInfo poolCreateInfo {


### PR DESCRIPTION
This pull request updates the descriptor pool configuration in the `ImGuiInstance` class to better support ImGui's use of textures. Specifically, it expands the types of descriptor pool sizes allocated, which should improve compatibility and prevent potential issues with texture sampling in ImGui.

Descriptor pool configuration:

* Updated the `createDescriptorPool` method in `ImGuiInstance.cpp` to allocate descriptor pool sizes for both `vk::DescriptorType::eSampler` and `vk::DescriptorType::eSampledImage`, instead of only `vk::DescriptorType::eCombinedImageSampler`. This change ensures that ImGui has the correct types of descriptors available for its texture usage.